### PR TITLE
Updated Enchantment Cap README.md

### DIFF
--- a/cyt-towny/content/enchantment-cap/README.md
+++ b/cyt-towny/content/enchantment-cap/README.md
@@ -10,32 +10,32 @@ The Enchantment Cap is our new increased levels for most Enchanted Books, these 
 
 ### How do I apply these books to my items?
 
-You can apply enchanted books to an item by using the Enchanter, a CYG machine that allows you to combine items with enchanted books! To obtain the Enchanter, unlock it at the Machines NPC in /warp trading.
+You can apply enchanted books to an item by dragging and dropping the enchanted books onto the item you wish to enchant.
 
 ### Upgrading Enchanted Books
 
 To upgrade an enchanted book, you will need to visit the Wizard at **/warp enchant**, and select Upgrade Enchanted Book.
 
-In the left slot, place the enchanted book you wish to upgrade, and in the right slot, the amount of [Ancient Coins](./#ancient-coins) that are needed to upgrade that enchanted book!
+In the left slot, place the enchanted book you wish to upgrade, and in the right slot, the amount of "upgrade tokens" (listed below) that are needed to upgrade that enchanted book! The more "tokens" you use, the higher chance of success you have!
 
 For a list of all upgrade recipes and enchantments that can be upgraded, [click here](upgrader-recipes.md).
 
 {% hint style="warning" %}
-There is a chance of the upgrade failing. In this case, you will receive a broken version of the book you were trying to upgrade, though your Ancient Coins will be still used up.
+There is a chance of the upgrade failing. In this case, you will receive a broken version of the book you were trying to upgrade, though your "upgrade tokens" will be still used up.
 {% endhint %}
 
 ### Repairing Broken Enchanted Books
 
 To repair a broken enchanted book, you will need to visit the Wizard at **/warp enchant**, and select Repair Enchanted Book.
 
-In the left slot, place the broken enchanted book you wish to repair, and in the right slot, the amount of [Ancient Coins](./#ancient-coins) that are needed to repair that enchanted book!
+In the left slot, place the broken enchanted book you wish to repair, and in the right slot, the amount of "upgrade tokens" that are needed to repair that enchanted book!
 
 ### Ancient Coin <a href="#ancient-coins" id="ancient-coins"></a>
 
 There are three types of Ancient Coin items:
 
 * Ancient Coin Fragments - Can be crafted into Ancient Coins, to do this you need use a [Constructor](../craftyourgadgets.md)!
-* Ancient Coins - Items that are used in every Upgrade and Repair recipe!
+* Ancient Coins - Items that are used to upgrade the enchanted books listed below
 * Enchanted Ancient Coins - Items that are used in every Upgrade and Repair recipe though don't allow the upgrade/repair to fail!
 
 Ancient Coins can be used to upgrade the following enchanted books:

--- a/cyt-towny/content/enchantment-cap/README.md
+++ b/cyt-towny/content/enchantment-cap/README.md
@@ -114,4 +114,4 @@ Refined Arrows can be used to upgrade the following enchanted books:
 Refined Arrows can be obtained by completing the following actions:
 
 * Killing Ranged Mobs:\
-  Skeleton, Drowned, Llama, Piglin, Trader Llama, Elder Guardian, Blaze, Ender Dragon, Evoker, Guardian
+  Skeleton, Drowned, Llama, Piglin, Trader Llama, Elder Guardian, Blaze, Ender Dragon, Evoker, Guardian, Warden


### PR DESCRIPTION
Updated Enchantment Cap page to reflect the changes made to the system.

Specifically:
- Removed reference to the Enchanter, since it hasn't worked in forever with no return in sight
- Corrected process on how to enchant items with the higher tiered books
- Swapped Ancient Coin references in the top part of the page and replaced them with "Upgrade Tokens" since there are many different types. I'm not sure what you call the new items internally, but it seemed to fit for now
- Updated book repair. No one has confirmed if you use Ancient Coins for all repairs or if you use the corresponding item in a few days, so I just assumed you use the new item.